### PR TITLE
Add support for recipe editing

### DIFF
--- a/src/main/java/commands/AddCommand.java
+++ b/src/main/java/commands/AddCommand.java
@@ -1,11 +1,13 @@
 package commands;
 
-import controller.ScreenState;
+import controller.KitchenCTRL;
 import model.Ingredient;
-import model.Recipe;
+import model.catalogue.Recipe;
 import model.catalogue.Catalogue;
 import model.catalogue.Inventory;
 import model.catalogue.RecipeBook;
+
+import static controller.ScreenState.*;
 
 /**
  * Represents a command to add an item (ingredient or recipe) to the appropriate catalogue
@@ -15,6 +17,7 @@ import model.catalogue.RecipeBook;
  * <ul>
  *     <li>Adding {@code Ingredient} to {@code Inventory}</li>
  *     <li>Adding a new {@code Recipe} to {@code RecipeBook}</li>
+ *     <li>Adding {@code Ingredient} to a selected {@code Recipe}</li>
  * </ul>
  */
 public class AddCommand extends Command {
@@ -24,37 +27,59 @@ public class AddCommand extends Command {
     /**
      * Constructs an {@code AddCommand} with the specified screen context, item name, and quantity.
      *
-     * @param screen   The screen state representing the active catalogue (INVENTORY, SHOPPING, or RECIPE).
      * @param name     The name of the ingredient or recipe to add.
      * @param quantity The quantity of the ingredient to add. Ignored for recipes.
-     * @throws AssertionError if {@code name} is null/empty, or {@code quantity} is not positive.
+     * @throws AssertionError if {@code name} is null/empty, or {@code quantity} is not positive (when required).
      */
-    public AddCommand(ScreenState screen, String name, int quantity) {
-        super(screen);
-        assert name != null && !name.trim().isEmpty() : "Ingredient name must not be null or empty";
-        assert quantity > 0 : "Ingredient quantity must be greater than zero";
+    public AddCommand(String name, int quantity) {
+        assert name != null && !name.trim().isEmpty() : "Name must not be null or empty";
+
+        assert screen == RECIPEBOOK || quantity > 0 : "Quantity must be greater than zero";
 
         this.name = name;
         this.quantity = quantity;
     }
+    public AddCommand(String name) {
+        assert name != null && !name.trim().isEmpty() : "Name must not be null or empty";
+
+
+        this.name = name;
+        this.quantity = 0;//irrelevant for recipebook screen
+    }
 
     /**
-     * Executes the add operation by determining the correct catalogue type based on runtime type checking.
+     * Executes the add operation based on the screen context.
      *
      * @param catalogue The catalogue to add the item to.
-     * @return A {@code CommandResult} indicating success or failure with feedback for the user.
+     * @return A {@code CommandResult} indicating success or failure with user feedback.
      */
     @Override
     public CommandResult execute(Catalogue<?> catalogue) {
         assert catalogue != null : "Catalogue must not be null";
-        if (catalogue instanceof Inventory inventory) {
-            Ingredient newIngredient = new Ingredient(name, quantity);
-            return inventory.addItem(newIngredient);
-        } else if (catalogue instanceof RecipeBook recipeBook) {
-            Recipe newRecipe = new Recipe();
-            return recipeBook.addItem(newRecipe);
-        } else {
-            return new CommandResult("Unsupported catalogue for AddCommand.", null);
-        }
+
+        return switch (KitchenCTRL.getCurrentScreen()) {
+            case INVENTORY -> {
+                if (catalogue instanceof Inventory inventory) {
+                    Ingredient ingredient = new Ingredient(name, quantity);
+                    yield inventory.addItem(ingredient);
+                }
+                yield new CommandResult("Invalid catalogue for inventory operation.", null);
+            }
+            case RECIPEBOOK -> {
+                if (catalogue instanceof RecipeBook recipeBook) {
+                    Recipe recipe = new Recipe(name);
+                    yield recipeBook.addItem(recipe);
+                }
+                yield new CommandResult("Invalid catalogue for recipe book operation.", null);
+            }
+            case RECIPE -> {
+                if (catalogue instanceof Recipe recipe) {
+                    Ingredient ingredient = new Ingredient(name, quantity);
+                    yield recipe.addItem(ingredient);
+                }
+                yield new CommandResult("Invalid catalogue for recipe operation.", null);
+            }
+            default -> new CommandResult("Unsupported screen state for AddCommand.", null);
+        };
     }
 }

--- a/src/main/java/commands/AddCommand.java
+++ b/src/main/java/commands/AddCommand.java
@@ -7,6 +7,7 @@ import model.catalogue.Catalogue;
 import model.catalogue.Inventory;
 import model.catalogue.RecipeBook;
 
+import static controller.KitchenCTRL.requireActiveRecipe;
 import static controller.ScreenState.*;
 
 /**
@@ -53,6 +54,7 @@ public class AddCommand extends Command {
      * @param catalogue The catalogue to add the item to.
      * @return A {@code CommandResult} indicating success or failure with user feedback.
      */
+
     @Override
     public CommandResult execute(Catalogue<?> catalogue) {
         assert catalogue != null : "Catalogue must not be null";
@@ -73,6 +75,7 @@ public class AddCommand extends Command {
                 yield new CommandResult("Invalid catalogue for recipe book operation.", null);
             }
             case RECIPE -> {
+                requireActiveRecipe();
                 if (catalogue instanceof Recipe recipe) {
                     Ingredient ingredient = new Ingredient(name, quantity);
                     yield recipe.addItem(ingredient);

--- a/src/main/java/commands/BackCommand.java
+++ b/src/main/java/commands/BackCommand.java
@@ -1,5 +1,6 @@
 package commands;
 
+import controller.KitchenCTRL;
 import controller.ScreenState;
 
 /**
@@ -19,6 +20,12 @@ public class BackCommand extends Command {
      */
     @Override
     public CommandResult execute() {
+        ScreenState current = KitchenCTRL.getCurrentScreen();
+
+        if (current == ScreenState.RECIPE) {
+            KitchenCTRL.setActiveRecipe(null); // clear context
+            return new CommandResult(ScreenState.RECIPEBOOK);
+        }
         return new CommandResult(ScreenState.WELCOME);
     }
 }

--- a/src/main/java/commands/CookRecipeCommand.java
+++ b/src/main/java/commands/CookRecipeCommand.java
@@ -1,9 +1,8 @@
 package commands;
 
 import controller.KitchenCTRL;
-import controller.ScreenState;
 import model.Ingredient;
-import model.Recipe;
+import model.catalogue.Recipe;
 import model.catalogue.Inventory;
 
 import java.util.ArrayList;
@@ -23,12 +22,11 @@ public class CookRecipeCommand extends Command {
     /**
      * Constructs a {@code CookRecipeCommand} with the specified recipe.
      *
-     * @param screen       The current screen context where the command is issued.
      * @param targetRecipe The recipe to be cooked.
      * @throws AssertionError if the recipeToCook is null.
      */
-    public CookRecipeCommand(ScreenState screen, Recipe targetRecipe) {
-        super(screen);
+    public CookRecipeCommand(Recipe targetRecipe) {
+
         assert targetRecipe != null : "Recipe to cook must not be null";
         this.targetRecipe = targetRecipe;
     }

--- a/src/main/java/commands/DeleteCommand.java
+++ b/src/main/java/commands/DeleteCommand.java
@@ -7,6 +7,7 @@ import model.catalogue.Catalogue;
 import model.catalogue.Inventory;
 import model.catalogue.RecipeBook;
 
+import static controller.KitchenCTRL.requireActiveRecipe;
 import static controller.ScreenState.*;
 
 /**
@@ -72,6 +73,7 @@ public class DeleteCommand extends Command {
                 yield new CommandResult("Invalid catalogue for recipe book operation.", null);
             }
             case RECIPE -> {
+                requireActiveRecipe();
                 if (catalogue instanceof Recipe recipe) {
                     Ingredient ingredient = new Ingredient(name, quantity);
                     yield recipe.deleteItem(ingredient);

--- a/src/main/java/commands/DeleteCommand.java
+++ b/src/main/java/commands/DeleteCommand.java
@@ -2,7 +2,7 @@ package commands;
 
 import controller.ScreenState;
 import model.Ingredient;
-import model.Recipe;
+import model.catalogue.Recipe;
 import model.catalogue.Catalogue;
 import model.catalogue.Inventory;
 import model.catalogue.RecipeBook;
@@ -23,13 +23,11 @@ public class DeleteCommand extends Command {
     /**
      * Constructs a {@code DeleteCommand} with the specified name and quantity.
      *
-     * @param screen   The current screen context where the delete command is issued.
      * @param name     The name of the item to be deleted (ingredient or recipe).
      * @param quantity The quantity to be removed (used only for ingredients).
      * @throws AssertionError if the name is null/empty or quantity is non-positive.
      */
-    public DeleteCommand(ScreenState screen, String name, int quantity) {
-        super(screen);
+    public DeleteCommand(String name, int quantity) {
         assert name != null && !name.trim().isEmpty() : "Ingredient name must not be null or empty";
         assert quantity > 0 : "Ingredient quantity must be greater than zero";
 

--- a/src/main/java/commands/EditRecipeCommand.java
+++ b/src/main/java/commands/EditRecipeCommand.java
@@ -1,0 +1,46 @@
+package commands;
+
+
+import controller.KitchenCTRL;
+import controller.ScreenState;
+import model.catalogue.Recipe;
+import model.catalogue.RecipeBook;
+
+/**
+ * Represents a command to enter a specific recipe for editing.
+ * It sets the active recipe in the controller and transitions to the RECIPE screen.
+ */
+public class EditRecipeCommand extends Command {
+    private final String recipeName;
+
+    /**
+     * Constructs an {@code EditRecipeCommand} with the given recipe name.
+     *
+     * @param args The name of the recipe to edit.
+     */
+    public EditRecipeCommand(String args) {
+        if (args == null || args.trim().isEmpty()) {
+            throw new IllegalArgumentException("Recipe name cannot be empty.");
+        }
+        this.recipeName = args.trim();
+        assert !recipeName.trim().isEmpty() : "Recipe name must not be null or empty";
+    }
+
+    /**
+     * Executes the command: sets the active recipe and transitions to RECIPE screen.
+     *
+     * @return A {@code CommandResult} with feedback and screen transition.
+     */
+    @Override
+    public CommandResult execute() {
+        RecipeBook recipeBook = KitchenCTRL.getRecipeBook();
+        Recipe recipe = recipeBook.getItemByName(recipeName);
+
+        if (recipe == null) {
+            return new CommandResult("Recipe not found: " + recipeName, ScreenState.RECIPEBOOK);
+        }
+
+        KitchenCTRL.setActiveRecipe(recipe);
+        return new CommandResult("Now editing recipe: " + recipeName, ScreenState.RECIPE);
+    }
+}

--- a/src/main/java/commands/ListCommand.java
+++ b/src/main/java/commands/ListCommand.java
@@ -1,6 +1,5 @@
 package commands;
 
-import controller.ScreenState;
 import model.catalogue.Catalogue;
 import model.catalogue.Inventory;
 import model.catalogue.RecipeBook;
@@ -17,12 +16,8 @@ import model.catalogue.RecipeBook;
 public class ListCommand extends Command {
     /**
      * Constructs a {@code ListCommand} with the specified screen context.
-     *
-     * @param screen The current screen state where this command is invoked.
      */
-    public ListCommand(ScreenState screen) {
-        super(screen);
-    }
+    public ListCommand() {}
 
     /**
      * Executes the list command by retrieving the list of items from the provided catalogue.

--- a/src/main/java/commands/ListCommand.java
+++ b/src/main/java/commands/ListCommand.java
@@ -2,6 +2,7 @@ package commands;
 
 import model.catalogue.Catalogue;
 import model.catalogue.Inventory;
+import model.catalogue.Recipe;
 import model.catalogue.RecipeBook;
 
 /**
@@ -34,7 +35,9 @@ public class ListCommand extends Command {
         assert catalogue != null : "Catalogue must not be null";
         if (catalogue instanceof Inventory inventory) {
             return inventory.listItems();
-        } else if (catalogue instanceof RecipeBook recipe) {
+        } else if (catalogue instanceof RecipeBook recipeBook) {
+            return recipeBook.listItems();
+        } else if (catalogue instanceof Recipe recipe){
             return recipe.listItems();
         } else {
             return new CommandResult("Unsupported catalogue for AddCommand.", null);

--- a/src/main/java/commands/UpdateCommand.java
+++ b/src/main/java/commands/UpdateCommand.java
@@ -1,0 +1,4 @@
+package commands;
+
+public class UpdateCommand {
+}

--- a/src/main/java/controller/KitchenCTRL.java
+++ b/src/main/java/controller/KitchenCTRL.java
@@ -1,12 +1,9 @@
 package controller;
 
-import commands.GoToCommand;
-import commands.BackCommand;
-import commands.ByeCommand;
-import commands.Command;
-import commands.CommandResult;
+import commands.*;
 
 import model.catalogue.Catalogue;
+import model.catalogue.Recipe;
 import model.catalogue.RecipeBook;
 import model.catalogue.Inventory;
 
@@ -35,6 +32,22 @@ public class KitchenCTRL {
 
     public static ScreenState getCurrentScreen() {
         return currentScreen;
+    }
+
+    private static Recipe activeRecipe;
+
+    public static void setActiveRecipe(Recipe recipe) {
+        activeRecipe = recipe;
+    }
+
+    public Recipe getActiveRecipe() {
+        return activeRecipe;
+    }
+
+    public static Recipe requireActiveRecipe() {
+        Recipe r = activeRecipe;
+        if (r == null) throw new IllegalStateException("No recipe is currently selected.");
+        return r;
     }
 
 
@@ -119,7 +132,8 @@ public class KitchenCTRL {
 
             CommandResult result;
             // Switch screen if required by result
-            if (command instanceof BackCommand || command instanceof GoToCommand) {
+            if (command instanceof BackCommand || command instanceof GoToCommand ||
+                    command instanceof EditRecipeCommand) {
                 result = command.execute();
                 currentScreen = result.getNewScreen();
                 ui.showDivider();
@@ -132,7 +146,7 @@ public class KitchenCTRL {
             // Execute the command and get result
             result = (catalogue == null)
                     ? command.execute() // e.g., welcome screen or global commands
-                    : command.execute(catalogue); // inventory/shopping/recipe screens
+                    : command.execute(catalogue); // inventory/shopping/active recipe
 
             // Display result to the user
             ui.showResultToUser(result);
@@ -158,6 +172,7 @@ public class KitchenCTRL {
         return switch (screen) {
         case INVENTORY -> inventory;
         case RECIPEBOOK -> recipeBook;
+        case RECIPE -> activeRecipe;
         default -> null; // For WELCOME, or throw if needed
         };
     }
@@ -176,5 +191,4 @@ public class KitchenCTRL {
         catalogues.add(recipeBook);
         return catalogues;
     }
-
 }

--- a/src/main/java/controller/KitchenCTRL.java
+++ b/src/main/java/controller/KitchenCTRL.java
@@ -31,6 +31,12 @@ public class KitchenCTRL {
 
     private Ui ui;
     private Parser parser;
+    private static ScreenState currentScreen = ScreenState.WELCOME;
+
+    public static ScreenState getCurrentScreen() {
+        return currentScreen;
+    }
+
 
     /**
      * Main entry-point for the KitchenCTRL application.
@@ -89,7 +95,6 @@ public class KitchenCTRL {
      * - Handles screen transitions and exit condition
      */
     private void runCommandLoopUntilExitCommand() {
-        ScreenState currentScreen = ScreenState.WELCOME;
         Command command;
 
         do {
@@ -101,7 +106,7 @@ public class KitchenCTRL {
 
             // Parse input into a Command
             try {
-                command = parser.parseCommand(currentScreen, userCommandText);
+                command = parser.parseCommand(userCommandText);
             } catch (IllegalArgumentException e) {
                 System.out.println(e.getMessage());
                 continue;
@@ -152,7 +157,7 @@ public class KitchenCTRL {
     private Catalogue<?> getCatalogueByScreen(ScreenState screen) {
         return switch (screen) {
         case INVENTORY -> inventory;
-        case RECIPE -> recipeBook;
+        case RECIPEBOOK -> recipeBook;
         default -> null; // For WELCOME, or throw if needed
         };
     }

--- a/src/main/java/controller/ScreenState.java
+++ b/src/main/java/controller/ScreenState.java
@@ -4,6 +4,7 @@ public enum ScreenState {
     WELCOME,
     INVENTORY,
     SHOPPING,
+    RECIPEBOOK,
     RECIPE,
     EXIT
 }

--- a/src/main/java/model/catalogue/Catalogue.java
+++ b/src/main/java/model/catalogue/Catalogue.java
@@ -69,7 +69,7 @@ public abstract class Catalogue<T> {
             return new CommandResult("No items found.");
         }
 
-        StringBuilder result = new StringBuilder("Inventory List:\n");
+        StringBuilder result = new StringBuilder("(override me) This catalogue contains the following list of items:\n");
         for (int i = 0; i < items.size(); i++) {
             result.append(i + 1).append(". ").append(items.get(i)).append("\n");
         }

--- a/src/main/java/model/catalogue/Recipe.java
+++ b/src/main/java/model/catalogue/Recipe.java
@@ -20,13 +20,13 @@ public class Recipe extends Catalogue<Ingredient> {
     @Override
     public CommandResult addItem(Ingredient ingredient) {
         items.add(ingredient);
-        return null;
+        return new CommandResult(ingredient.getIngredientName() + " added to recipe for " + getRecipeName() + ".");
     }
 
     @Override
     public CommandResult deleteItem(Ingredient ingredient) {
         items.remove(ingredient);
-        return null;
+        return new CommandResult(ingredient.getIngredientName() + " deleted from recipe for " + getRecipeName() + ".");
     }
 
     //this is to get the name of an ingredient in the recipe by the name of the ingredient

--- a/src/main/java/model/catalogue/Recipe.java
+++ b/src/main/java/model/catalogue/Recipe.java
@@ -1,7 +1,8 @@
-package model;
+package model.catalogue;
 
 import commands.CommandResult;
-import model.catalogue.Catalogue;
+import model.Ingredient;
+
 public class Recipe extends Catalogue<Ingredient> {
     private String recipeName;
 

--- a/src/main/java/model/catalogue/RecipeBook.java
+++ b/src/main/java/model/catalogue/RecipeBook.java
@@ -1,7 +1,6 @@
 package model.catalogue;
 
 import commands.CommandResult;
-import model.Recipe;
 import ui.inputparser.InputParser;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,10 +26,16 @@ public class RecipeBook extends Catalogue<Recipe> {
      *
      * @param recipe The recipe whose name is to be retrieved.
      * @return The lowercase name of the recipe.
+     * @throws IllegalArgumentException if the recipe name is null or empty.
      */
     private String getRecipeNameLowercase(Recipe recipe) {
-        return recipe.getRecipeName().toLowerCase();
+        String name = recipe.getRecipeName();
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException("Recipe does not exist in system");
+        }
+        return name.toLowerCase();
     }
+
 
     /**
      * Searches for recipes with similar names.

--- a/src/main/java/ui/inputparser/InputParser.java
+++ b/src/main/java/ui/inputparser/InputParser.java
@@ -1,7 +1,7 @@
 package ui.inputparser;
 
 import model.Ingredient;
-import model.Recipe;
+import model.catalogue.Recipe;
 
 import java.util.ArrayList;
 import java.util.Scanner;

--- a/src/main/java/ui/inputparser/Parser.java
+++ b/src/main/java/ui/inputparser/Parser.java
@@ -1,13 +1,6 @@
 package ui.inputparser;
 
-import commands.ByeCommand;
-import commands.AddCommand;
-import commands.CookRecipeCommand;
-import commands.DeleteCommand;
-import commands.BackCommand;
-import commands.Command;
-import commands.ListCommand;
-import commands.GoToCommand;
+import commands.*;
 
 import controller.KitchenCTRL;
 import controller.ScreenState;
@@ -94,6 +87,7 @@ public class Parser {
         case "back" -> prepareBack();
         case "bye" -> new ByeCommand();
         case "cook" -> prepareCook(args);
+        case "edit" -> new EditRecipeCommand(args);
         default -> throw new IllegalArgumentException("Unknown command in RecipeBook screen.");
         };
     }

--- a/src/main/java/ui/inputparser/Parser.java
+++ b/src/main/java/ui/inputparser/Parser.java
@@ -166,23 +166,42 @@ public class Parser {
      * @throws IllegalArgumentException If the input format is invalid or quantity is not a number.
      */
     private Command prepareDelete(String args) {
-        String[] parts = args.split(" ", 2); // Expecting format: "name quantity"
+        String currentScreenName = KitchenCTRL.getCurrentScreen().name(); // for error msg
 
-        if (parts.length < 2) {
-            throw new IllegalArgumentException("Invalid format! Usage: delete <name> <quantity>");
+        switch (KitchenCTRL.getCurrentScreen()) {
+            case RECIPEBOOK -> {
+                // RECIPEBOOK expects only the recipe name
+                String name = args.trim();
+                if (name.isEmpty()) {
+                    throw new IllegalArgumentException("Invalid format! Usage: delete <recipeName>");
+                }
+                return new DeleteCommand(name); // uses the recipe-only constructor
+            }
+
+            case INVENTORY, RECIPE -> {
+                // INVENTORY and RECIPE expect: delete <name> <quantity>
+                String[] parts = args.split(" ", 2);
+                if (parts.length < 2) {
+                    throw new IllegalArgumentException("Invalid format! Usage: delete <name> <quantity>");
+                }
+
+                String name = parts[0].trim();
+                int quantity;
+                try {
+                    quantity = Integer.parseInt(parts[1].trim());
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Quantity must be a valid integer!");
+                }
+
+                return new DeleteCommand(name, quantity);
+            }
+
+            default -> throw new IllegalArgumentException(
+                    "Delete command is not supported in screen: " + currentScreenName
+            );
         }
-
-        String name = parts[0].trim();
-        int quantity;
-
-        try {
-            quantity = Integer.parseInt(parts[1].trim());
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Quantity must be a valid integer!");
-        }
-
-        return new DeleteCommand(name, quantity);
     }
+
 
     /**
      * Creates a {@code ListCommand} for listing contents of the current catalogue.

--- a/src/main/java/ui/inputparser/Ui.java
+++ b/src/main/java/ui/inputparser/Ui.java
@@ -150,6 +150,7 @@ public class Ui {
         System.out.println("- list → Show all recipes");
         System.out.println("- add [name] → Add a new recipe");
         System.out.println("- delete [name] → Delete a recipe");
+        System.out.println("- edit [name] → edit a recipe");
         System.out.println("- back → Return to the main screen");
         System.out.println("- bye → Exit the program");
     }

--- a/src/main/java/ui/inputparser/Ui.java
+++ b/src/main/java/ui/inputparser/Ui.java
@@ -78,6 +78,9 @@ public class Ui {
         case SHOPPING:
             showShoppingMessage();
             break;
+        case RECIPEBOOK:
+            showRecipeBookMessage();
+            break;
         case RECIPE:
             showRecipeMessage();
             break;
@@ -125,11 +128,25 @@ public class Ui {
     }
 
     /**
-     * Displays help and commands for the RECIPE screen.
+     * Displays help and commands for managing a specific recipe's ingredients.
      */
     private void showRecipeMessage() {
-        System.out.println("You’re now in the RECIPE screen.");
-        System.out.println("What would you like to make today? Available commands:");
+        System.out.println("You’re now viewing a specific RECIPE.");
+        System.out.println("Manage the ingredients for this recipe. Available commands:");
+        System.out.println("- list → Show all ingredients in the recipe");
+        System.out.println("- add [item] [qty] → Add an ingredient to the recipe");
+        System.out.println("- update [item] [qty] → Update the quantity of an existing ingredient");
+        System.out.println("- delete [item] → Remove an ingredient from the recipe");
+        System.out.println("- back → Return to the recipe list");
+        System.out.println("- bye → Exit the program");
+    }
+
+    /**
+     * Displays help and commands for the RECIPE screen.
+     */
+    private void showRecipeBookMessage() {
+        System.out.println("You’re now in the RECIPEBOOK screen.");
+        System.out.println("What dish would you like to make today? Available commands:");
         System.out.println("- list → Show all recipes");
         System.out.println("- add [name] → Add a new recipe");
         System.out.println("- delete [name] → Delete a recipe");

--- a/src/test/java/kitchenctrl/CatalogueTest.java
+++ b/src/test/java/kitchenctrl/CatalogueTest.java
@@ -3,7 +3,7 @@ package kitchenctrl;
 import model.catalogue.Inventory;
 import model.catalogue.RecipeBook;
 import model.Ingredient;
-import model.Recipe;
+import model.catalogue.Recipe;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/src/test/java/kitchenctrl/LogicTest.java
+++ b/src/test/java/kitchenctrl/LogicTest.java
@@ -4,13 +4,13 @@ import commands.CommandResult;
 import commands.CookRecipeCommand;
 import controller.KitchenCTRL;
 import controller.ScreenState;
-import model.Recipe;
+import model.catalogue.Recipe;
 import model.catalogue.Inventory;
 import model.Ingredient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static controller.ScreenState.RECIPE;
+import static controller.ScreenState.RECIPEBOOK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
@@ -25,7 +25,7 @@ public class LogicTest {
         KitchenCTRL mainApp = new KitchenCTRL();  // Instantiate Main class
         mainApp.initializeCatalogues();
         testInventory = KitchenCTRL.getInventory();  // Get inventory from Main class
-        testScreen = RECIPE;
+        testScreen = RECIPEBOOK;
     }
 
     @Test
@@ -39,7 +39,7 @@ public class LogicTest {
         targetRecipe.addItem(new Ingredient("Eggs", 2));
         targetRecipe.addItem(new Ingredient("Milk", 300));
 
-        CookRecipeCommand command = new CookRecipeCommand(testScreen, targetRecipe);
+        CookRecipeCommand command = new CookRecipeCommand(targetRecipe);
         ArrayList<Ingredient> missingIngredients = command.getMissingIngredients(testInventory);
         ArrayList<Ingredient> expectedMissing = new ArrayList<>();
         expectedMissing.add(new Ingredient("Milk", 50));
@@ -58,7 +58,7 @@ public class LogicTest {
         recipe.addItem(new Ingredient("Eggs", 2));
         recipe.addItem(new Ingredient("Milk", 300));
 
-        CookRecipeCommand command = new CookRecipeCommand(testScreen, recipe);
+        CookRecipeCommand command = new CookRecipeCommand(recipe);
         ArrayList<Ingredient> missingIngredients = command.getMissingIngredients(testInventory);
 
         assertTrue(missingIngredients.isEmpty(), "There should be enough ingredients");
@@ -75,7 +75,7 @@ public class LogicTest {
         recipe.addItem(new Ingredient("Milk", 300));
         recipe.addItem(new Ingredient("Eggs", 2));
 
-        CookRecipeCommand command = new CookRecipeCommand(testScreen, recipe);
+        CookRecipeCommand command = new CookRecipeCommand(recipe);
         ArrayList<Ingredient> missingIngredients = command.getMissingIngredients(testInventory);
         ArrayList<Ingredient> expectedMissing = new ArrayList<>();
         expectedMissing.add(new Ingredient("Milk", 300));
@@ -94,7 +94,7 @@ public class LogicTest {
         recipe.addItem(new Ingredient("Flour", 300));
         recipe.addItem(new Ingredient("Eggs", 2));
 
-        CookRecipeCommand command = new CookRecipeCommand(testScreen, recipe);
+        CookRecipeCommand command = new CookRecipeCommand(recipe);
         CommandResult result = command.execute(); // Pass the inventory
 
         assertEquals("Recipe successfully cooked: Pancakes", result.getFeedbackToUser());

--- a/src/test/java/kitchenctrl/ParserTest.java
+++ b/src/test/java/kitchenctrl/ParserTest.java
@@ -26,7 +26,7 @@ class ParserTest {
 
     @Test
     public void testWelcomeCommand_inventory() {
-        Command command = parser.parseCommand(ScreenState.WELCOME, "inventory");
+        Command command = parser.parseCommand("inventory");
         assertInstanceOf(GoToCommand.class, command);
 
         CommandResult result = command.execute();
@@ -36,17 +36,17 @@ class ParserTest {
 
     @Test
     public void testWelcomeCommand_recipe() {
-        Command command = parser.parseCommand(ScreenState.WELCOME, "recipe");
+        Command command = parser.parseCommand("recipe");
         assertInstanceOf(GoToCommand.class, command);
 
         CommandResult result = command.execute();
         assertTrue(result.isScreenSwitch());
-        assertEquals(ScreenState.RECIPE, result.getNewScreen());
+        assertEquals(ScreenState.RECIPEBOOK, result.getNewScreen());
     }
 
     @Test
     public void testWelcomeCommand_bye() {
-        Command command = parser.parseCommand(ScreenState.WELCOME, "bye");
+        Command command = parser.parseCommand("bye");
         assertInstanceOf(ByeCommand.class, command);
 
         CommandResult result = command.execute();
@@ -56,38 +56,38 @@ class ParserTest {
     @Test
     public void testWelcomeCommand_invalid1() {
         assertThrows(IllegalArgumentException.class, () ->
-                parser.parseCommand(ScreenState.WELCOME, "unknown"));
+                parser.parseCommand("unknown"));
     }
 
     @Test
     public void testWelcomeCommand_invalid2() {
         assertThrows(IllegalArgumentException.class, () ->
-                parser.parseCommand(ScreenState.EXIT, "inventory"));
+                parser.parseCommand("inventory"));
     }
 
     // --- INVENTORY SCREEN COMMANDS ---
 
     @Test
     public void testInventoryCommand_valid() {
-        Command command = parser.parseCommand(ScreenState.INVENTORY, "add apple 5");
+        Command command = parser.parseCommand("add apple 5");
         assertInstanceOf(AddCommand.class, command);
     }
 
     @Test
     public void testInventoryCommand_delete_valid() {
-        Command command = parser.parseCommand(ScreenState.INVENTORY, "delete sugar 2");
+        Command command = parser.parseCommand("delete sugar 2");
         assertInstanceOf(DeleteCommand.class, command);
     }
 
     @Test
     public void testInventoryCommand_list() {
-        Command command = parser.parseCommand(ScreenState.INVENTORY, "list");
+        Command command = parser.parseCommand("list");
         assertInstanceOf(ListCommand.class, command);
     }
 
     @Test
     public void testInventoryCommand_back() {
-        Command command = parser.parseCommand(ScreenState.INVENTORY, "back");
+        Command command = parser.parseCommand("back");
         assertInstanceOf(BackCommand.class, command);
 
         CommandResult result = command.execute();
@@ -96,38 +96,38 @@ class ParserTest {
 
     @Test
     public void testInventoryCommand_bye() {
-        Command command = parser.parseCommand(ScreenState.INVENTORY, "bye");
+        Command command = parser.parseCommand("bye");
         assertInstanceOf(ByeCommand.class, command);
     }
 
     @Test
     public void testInventoryCommand_invalidFormat() {
         assertThrows(IllegalArgumentException.class, () ->
-                parser.parseCommand(ScreenState.INVENTORY, "aaaaaaaa"));
+                parser.parseCommand("aaaaaaaa"));
     }
 
     @Test
     public void testInventoryCommand_add_invalidFormat() {
         assertThrows(IllegalArgumentException.class, () ->
-                parser.parseCommand(ScreenState.INVENTORY, "add milk"));
+                parser.parseCommand("add milk"));
     }
 
     @Test
     public void testInventoryCommand_add_invalidQuantity() {
         assertThrows(IllegalArgumentException.class, () ->
-                parser.parseCommand(ScreenState.INVENTORY, "add milk two"));
+                parser.parseCommand("add milk two"));
     }
 
     @Test
     public void testInventoryCommand_delete_invalidFormat() {
         assertThrows(IllegalArgumentException.class, () ->
-                parser.parseCommand(ScreenState.INVENTORY, "delete milk"));
+                parser.parseCommand("delete milk"));
     }
 
     @Test
     public void testInventoryCommand_delete_invalidQuantity() {
         assertThrows(IllegalArgumentException.class, () ->
-                parser.parseCommand(ScreenState.INVENTORY, "delete milk two"));
+                parser.parseCommand("delete milk two"));
     }
 
     // --- SHOPPING SCREEN COMMANDS ---
@@ -197,25 +197,25 @@ class ParserTest {
 
     @Test
     public void testRecipeCommand_add_valid() {
-        Command command = parser.parseCommand(ScreenState.RECIPE, "add curry 1");
+        Command command = parser.parseCommand("add curry 1");
         assertInstanceOf(AddCommand.class, command);
     }
 
     @Test
     public void testRecipeCommand_delete_valid() {
-        Command command = parser.parseCommand(ScreenState.RECIPE, "delete curry 1");
+        Command command = parser.parseCommand("delete curry 1");
         assertInstanceOf(DeleteCommand.class, command);
     }
 
     @Test
     public void testRecipeCommand_list() {
-        Command command = parser.parseCommand(ScreenState.RECIPE, "list");
+        Command command = parser.parseCommand("list");
         assertInstanceOf(ListCommand.class, command);
     }
 
     @Test
     public void testRecipeCommand_back() {
-        Command command = parser.parseCommand(ScreenState.RECIPE, "back");
+        Command command = parser.parseCommand("back");
         assertInstanceOf(BackCommand.class, command);
 
         CommandResult result = command.execute();
@@ -224,14 +224,14 @@ class ParserTest {
 
     @Test
     public void testRecipeCommand_bye() {
-        Command command = parser.parseCommand(ScreenState.RECIPE, "bye");
+        Command command = parser.parseCommand("bye");
         assertInstanceOf(ByeCommand.class, command);
     }
 
     @Test
     public void testRecipeCommand_invalid() {
         assertThrows(IllegalArgumentException.class, () ->
-                parser.parseCommand(ScreenState.RECIPE, "notarealcommand"));
+                parser.parseCommand("notarealcommand"));
     }
 
     // --- ERROR CASES ---
@@ -239,6 +239,6 @@ class ParserTest {
     @Test
     public void testInvalidScreenState() {
         assertThrows(IllegalArgumentException.class, () ->
-                parser.parseCommand(ScreenState.SHOPPING, "add eggs 2"));
+                parser.parseCommand("add eggs 2"));
     }
 }

--- a/src/test/java/kitchenctrl/RecipeBookTest.java
+++ b/src/test/java/kitchenctrl/RecipeBookTest.java
@@ -1,6 +1,6 @@
 package kitchenctrl;
 
-import model.Recipe;
+import model.catalogue.Recipe;
 import model.catalogue.RecipeBook;
 import commands.CommandResult;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/kitchenctrl/UiTest.java
+++ b/src/test/java/kitchenctrl/UiTest.java
@@ -109,7 +109,7 @@ class UiTest {
 
     @Test
     public void testShowScreenPromptRecipe() {
-        ui.showScreenPrompt(ScreenState.RECIPE);
+        ui.showScreenPrompt(ScreenState.RECIPEBOOK);
         String output = outContent.toString();
 
         assertTrue(output.contains("You’re now in the RECIPE screen."));


### PR DESCRIPTION
Adds EditRecipeCommand to allow entering a specific recipe editing context.

Stores the active recipe in KitchenCTRL for use across RECIPE screen commands.

Updates AddCommand, DeleteCommand, and related handlers to support RECIPE screen actions.

Refactors screen state handling to reduce method parameter clutter.

Refines parser logic to auto-route based on current screen instead of passing ScreenState around.